### PR TITLE
constructor errors solved

### DIFF
--- a/contracts/CrossChainToken.sol
+++ b/contracts/CrossChainToken.sol
@@ -16,7 +16,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 contract CrossChainToken is NonblockingLzApp, ERC20 {
     uint16 destChainId;
     
-    constructor(address _lzEndpoint) NonblockingLzApp(_lzEndpoint) ERC20("Cross Chain Token", "CCT") {
+    constructor(address _lzEndpoint) NonblockingLzApp(_lzEndpoint) ERC20("Cross Chain Token", "CCT") Ownable(msg.sender) {
         if (_lzEndpoint == 0xae92d5aD7583AD66E49A0c67BAd18F6ba52dDDc1) destChainId = 10121;
         if (_lzEndpoint == 0xbfD2135BFfbb0B5378b56643c2Df8a87552Bfa23) destChainId = 10132;
         _mint(msg.sender, 1000000 * 10 ** decimals());

--- a/contracts/LayerZeroTest.sol
+++ b/contracts/LayerZeroTest.sol
@@ -16,7 +16,7 @@ contract LayerZeroTest is NonblockingLzApp {
     string public data = "Nothing received yet";
     uint16 destChainId;
     
-    constructor(address _lzEndpoint) NonblockingLzApp(_lzEndpoint) {
+    constructor(address _lzEndpoint) NonblockingLzApp(_lzEndpoint) Ownable(msg.sender) {
         if (_lzEndpoint == 0xae92d5aD7583AD66E49A0c67BAd18F6ba52dDDc1) destChainId = 10121;
         if (_lzEndpoint == 0xbfD2135BFfbb0B5378b56643c2Df8a87552Bfa23) destChainId = 10132;
     }


### PR DESCRIPTION
Solved  error "TypeError: No arguments passed to the base constructor. Specify the arguments or mark “*” as abstract." with adding " Ownable(msg.sender)" to constructor. This error was due to OpenZeppeling v5 changes.